### PR TITLE
Update maintainers of KEDA & voting process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-*       @zroubalik @tomkerkhove @jeffhollan @anirudhgarg @ahmelsayed 
+*       @zroubalik @tomkerkhove @jeffhollan @ahmelsayed 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,9 @@
 # Governance
 
+## Voting
+
+All decisions made by maintainers have to be a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) where every maintainers representing the same company only have one vote. This enables our project to be neutral and not have a single company have more weight over others.
+
 ## Project Maintainers
 
 [Project maintainers](MAINTAINERS.md) are responsible for activities around

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,16 +4,16 @@
 
 | Maintainer           | GitHub ID                                     | Affiliation |
 | -------------------- | --------------------------------------------- | ----------- |
-| Jeff Hollan          | [jeffhollan](https://github.com/jeffhollan)   | Microsoft   |
-| Anirudh Garg         | [anirudhgarg](https://github.com/anirudhgarg) | Microsoft   |
 | Ahmed ElSayed        | [ahmelsayed](https://github.com/ahmelsayed)   | Microsoft   |
-| Zbynek Roubalik      | [zroubalik](https://github.com/zroubalik)     | Red Hat     |
+| Jeff Hollan          | [jeffhollan](https://github.com/jeffhollan)   | Microsoft   |
 | Tom Kerkhove         | [tomkerkhove](https://github.com/tomkerkhove) | Codit       |
+| Zbynek Roubalik      | [zroubalik](https://github.com/zroubalik)     | Red Hat     |
 
 ## Alumni
 
 | Maintainer           | GitHub ID                                     | Affiliation |
 | -------------------- | --------------------------------------------- | ----------- |
 | Aarthi Saravanakumar | [Aarthisk](https://github.com/Aarthisk)       | Microsoft   |
-| Yaron Schneider      | [yaron2](https://github.com/yaron2)           | Microsoft   |
+| Anirudh Garg         | [anirudhgarg](https://github.com/anirudhgarg) | Microsoft   |
 | Ben Browning         | [bbrowning](https://github.com/bbrowning)     | Red Hat     |
+| Yaron Schneider      | [yaron2](https://github.com/yaron2)           | Microsoft   |


### PR DESCRIPTION
As agreed yesterday with @jeffhollan @zroubalik we are changing our voting process so that every company that is represented gets equal weight in the voting process. This means that @jeffhollan & @ahmelsayed now share one vote as they both represent Microsoft.

We have also removed @anirudhgarg in our maintainer overview as per https://github.com/kedacore/governance/issues/17, thank you for your service! 🙏