### PR TITLE
docs: Provide release plan governance

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,13 +1,43 @@
 # Releases
 
-TODO
+This document describes how KEDA handles versioning, releases new versions and communicates about them.
 
-## TODO
+KEDA uses semantic versioning so that their users can reliably upgrade according to their needs.
 
-- We should use GitHub Milestones better so that we add all issues/PRs that have been closed and will be included in the next release. As part of that, we can use the due date to show our intended release date
-- We should always create a GitHub Discussion linked to our release so that people get notified and can join the discussion (release also gives notification but no discussion)
-- We need to come up with a reasonable window for our cycle, for example ship every 2mo
-- We use semantic versioning
-- We provide a changelog with all changes per version and include them in releases as well
-- We need to define a procedure to deprecate features
-- We will always provide a migration guide for new major versions ([example](https://keda.sh/docs/latest/migration/))
+## Release Cycle
+
+As of today, KEDA is typically shipped on demand without a fixed release schedule.
+
+However, this is currently being discussed on [GitHub](https://github.com/kedacore/governance/issues/24).
+
+## Release Process
+
+You can learn about our release process [here](https://github.com/kedacore/keda/blob/main/RELEASE-PROCESS.MD).
+
+## Keeping Track Of Changes
+
+We provide a changelog that includes every change per version must be available as part of the repo, for example, here is the changelog for [KEDA Core](https://github.com/kedacore/keda/blob/main/CHANGELOG.md).
+
+Next to that, every closed issue and PR should be added to a GitHub Milestone that provides an overview of everything that will be included and provide an indication of what the current intended release date is. However, the release date is subject to change and only provides an indication.
+
+Lastly, every new release will come with a GitHub Release which provides the exact changelog for that release.
+
+## Get Notified For New Releases
+
+If you want to be notified of new releases, we recommend [watching](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository) our [KEDA Core repository](https://github.com/kedacore/keda) on GitHub and ensure you are subscribing for releases.
+
+Next to that, you can join the conversation for every new release on [GitHub Discussions](https://github.com/kedacore/keda/discussions/categories/announcements).
+
+## Removing Features, Breaking Changes & Deprecations
+
+Every new major version, KEDA maintainers are allowed to remove features or make breaking changes as per [semantic versioning](https://semver.org/).
+
+Along with such a release there will always be a migration guide to provide an overview of what has changed, what the impact is and how to migrate. Here is an example of our v1.x to v2.0 migration guide ([example](https://keda.sh/docs/latest/migration/)).
+
+For every one of these, KEDA will always announce a deprecation notice on [GitHub Discussions](https://github.com/kedacore/keda/discussions/categories/announcements) that provides context on why it is changing, what the impact is, when it will change and what steps that are required to be taken.
+
+In majority of the cases, we will allow you to already migrate in the next minor version where we introduce the deprecation so that you can migrate fast.
+
+## Support
+
+Learn more about our support policy [here](https://github.com/kedacore/governance/blob/main/SUPPORT.md).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,13 @@
+# Releases
+
+TODO
+
+## TODO
+
+- We should use GitHub Milestones better so that we add all issues/PRs that have been closed and will be included in the next release. As part of that, we can use the due date to show our intended release date
+- We should always create a GitHub Discussion linked to our release so that people get notified and can join the discussion (release also gives notification but no discussion)
+- We need to come up with a reasonable window for our cycle, for example ship every 2mo
+- We use semantic versioning
+- We provide a changelog with all changes per version and include them in releases as well
+- We need to define a procedure to deprecate features
+- We will always provide a migration guide for new major versions ([example](https://keda.sh/docs/latest/migration/))

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -34,7 +34,7 @@ Every new major version, KEDA maintainers are allowed to remove features or make
 
 Along with such a release there will always be a migration guide to provide an overview of what has changed, what the impact is and how to migrate. Here is an example of our v1.x to v2.0 migration guide ([example](https://keda.sh/docs/latest/migration/)).
 
-For every one of these, KEDA will always announce a deprecation notice on [GitHub Discussions](https://github.com/kedacore/keda/discussions/categories/announcements) that provides context on why it is changing, what the impact is, when it will change and what steps that are required to be taken.
+For every one of these, KEDA will always announce a deprecation notice on [GitHub Discussions](https://github.com/kedacore/keda/discussions/categories/deprecations) that provides context on why it is changing, what the impact is, when it will change and what steps that are required to be taken.
 
 In majority of the cases, we will allow you to already migrate in the next minor version where we introduce the deprecation so that you can migrate fast.
 


### PR DESCRIPTION
Provide release plan governance that talks about when we ship, what our release cadence is, etc.

Discussion around a fixed release cycle was started in #24 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #23