### PR TITLE
docs: @tomkerkhove represents Microsoft instead of Codit

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,7 @@
 | -------------------- | --------------------------------------------- | ----------- |
 | Ahmed ElSayed        | [ahmelsayed](https://github.com/ahmelsayed)   | Microsoft   |
 | Jeff Hollan          | [jeffhollan](https://github.com/jeffhollan)   | Microsoft   |
-| Tom Kerkhove         | [tomkerkhove](https://github.com/tomkerkhove) | Codit       |
+| Tom Kerkhove         | [tomkerkhove](https://github.com/tomkerkhove) | Microsoft   |
 | Zbynek Roubalik      | [zroubalik](https://github.com/zroubalik)     | Red Hat     |
 
 ## Alumni


### PR DESCRIPTION
@tomkerkhove represents Microsoft instead of Codit

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

