### PR TITLE
docs: Provide link to HTTP add-on roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@
 
 Provides resources related to governance of KEDA:
 
-- [Branding](BRANDING.md)
-- [Code of Conduct](https://github.com/kedacore/.github/blob/main/CODE_OF_CONDUCT.md)
-- [Governance](GOVERNANCE.md)
-- [Maintainers](MAINTAINERS.md)
-- [Releases](RELEASES.md)
-- [Roadmap](https://github.com/kedacore/keda/blob/main/ROADMAP.md)
-- [Support](SUPPORT.md)
+- [**Branding**](BRANDING.md)
+- [**Code of Conduct**](https://github.com/kedacore/.github/blob/main/CODE_OF_CONDUCT.md)
+- [**Governance**](GOVERNANCE.md)
+- [**Maintainers**](MAINTAINERS.md)
+- [**Releases**](RELEASES.md)
+- **Roadmap**
+  - [KEDA Core](https://github.com/kedacore/keda/blob/main/ROADMAP.md)
+  - [KEDA HTTP Add-On](https://github.com/kedacore/http-add-on/blob/main/ROADMAP.md)
+- [**Support**](SUPPORT.md)
 
 We are a Cloud Native Computing Foundation (CNCF) incubation project.
 <p align="center"><img src="logos/logo-cncf.svg" height="75px"></p>


### PR DESCRIPTION
Provide link to HTTP add-on roadmap

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/http-add-on/issues/446
