### PR TITLE
chore: Remove @tomkerkhove as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,6 @@
 | --------------------- | --------------------------------------------- | ---------------------------- |
 | Jeff Hollan           | [jeffhollan](https://github.com/jeffhollan)   | Snowflake                    |
 | Jorge Turrado Ferrero | [jorturfer](https://github.com/jorturfer)     | SCRM Lidl International Hub  |
-| Tom Kerkhove          | [tomkerkhove](https://github.com/tomkerkhove) | Microsoft                    |
 | Zbynek Roubalik       | [zroubalik](https://github.com/zroubalik)     | Kedify                       |
 | Jan Wozniak           | [wozniakjan](https://github.com/wozniakjan)   | Kedify                       |
 
@@ -18,4 +17,5 @@
 | Ahmed ElSayed        | [ahmelsayed](https://github.com/ahmelsayed)   |
 | Anirudh Garg         | [anirudhgarg](https://github.com/anirudhgarg) |
 | Ben Browning         | [bbrowning](https://github.com/bbrowning)     |
+| Tom Kerkhove         | [bbrowning](https://github.com/tomkerkhove)   |
 | Yaron Schneider      | [yaron2](https://github.com/yaron2)           |


### PR DESCRIPTION
Remove @tomkerkhove as maintainer

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Relates to https://github.com/kedacore/governance/issues/115
