### PR TITLE
Change Jorge Turrado Ferrero's affiliation

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -6,7 +6,7 @@
 | --------------------- | --------------------------------------------- | ----------------------- |---------------------------------- |
 | Jan Wozniak           | [wozniakjan](https://github.com/wozniakjan)   | Organization Maintainer | Kedify                            |
 | Jeff Hollan           | [jeffhollan](https://github.com/jeffhollan)   | Organization Maintainer | Snowflake                         |
-| Jorge Turrado Ferrero | [jorturfer](https://github.com/jorturfer)     | Organization Maintainer | SCRM Lidl International Hub       |
+| Jorge Turrado Ferrero | [jorturfer](https://github.com/jorturfer)     | Organization Maintainer | Schwarz Digits                    |
 | Zbynek Roubalik       | [zroubalik](https://github.com/zroubalik)     | Organization Maintainer | Kedify                            |
 
 ## [keda](https://github.com/kedacore/keda)


### PR DESCRIPTION
Updated the affiliation of Jorge Turrado Ferrero from 'SCRM Lidl International Hub' to 'Schwarz Digits'.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
